### PR TITLE
Fix: Missing dependency of package rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Role Variables
 | `quiet_assert`                               | `true`                       | false    | whether to quiet asserts                                                       |
 | `redhat_portal_auth_url`                     | Check in `defaults/main.yml` | false    | URL to the Red Hat Portal to authenticate against                              |
 | `redhat_portal_download_base_url`            | Check in `defaults/main.yml` | false    | base URL for image downloading from the Red Hat Customer Portal                |
+| `rsync_package_name`                         | `rsync`                      | false    | name of the package that provides the command `rsync`                          |
 | `temporary_mount_path`                       | `/mnt`                       | false    | path to a temporary (empty) mount point to mount the downloaded ISO to         |
 | `temporary_work_dir_path`                    | `{{ playbook_dir }}/workdir` | false    | temporary directory which will be used to extract the ISO files to             |
 | `temporary_work_dir_path_group`              | `root`                       | false    | group of the temporary directory to apply                                      |
@@ -190,6 +191,7 @@ Dependencies
 
 This role makes use of the [Ansible Posix collection](https://github.com/ansible-collections/ansible.posix).
 Depending on whether certain actions are required, the role needs to install the following packages:
+- `rsync`: To extract files from mounted ISO to work directory
 - `xorriso`: To create a custom ISO
 - `isomd5sum`: To implant a MD5 checksum into a custom ISO
 - `pykickstart`: To validate a given Kickstart file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,9 @@ _def_dest_dir_path_mode: '0755'
 # name of the package that provides xorriso
 _def_xorriso_package_name: 'xorriso'
 
+# name of the package that provides rsync
+_def_rsync_package_name: 'rsync'
+
 # relative path within the temporary_work_dir_source_files_path to the isolinux.bin file
 _def_isolinux_bin_path: 'isolinux/isolinux.bin'
 

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -51,6 +51,7 @@
     - '_dest_dir_path_group'
     - '_dest_dir_path_mode'
     - '_xorriso_package_name'
+    - '_rsync_package_name'
     - '_isolinux_bin_path'
     - '_boot_cat_path'
     - '_pxelinux_cfg_path'

--- a/tasks/extract_files.yml
+++ b/tasks/extract_files.yml
@@ -5,6 +5,12 @@
     state: 'unmounted'
   become: true
 
+- name: 'extract_files | Ensure rsync is present'
+  ansible.builtin.package:
+    name: '{{ _rsync_package_name }}'
+    state: 'present'
+  become: true
+
 - name: 'extract_files | Mount downloaded ISO to extract contents'
   ansible.posix.mount:
     path: '{{ _temporary_mount_path }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -84,6 +84,9 @@ _dest_iso_filename: '{{ dest_iso_filename | default(None) }}'
 # name of the package that provides xorriso
 _xorriso_package_name: '{{ xorriso_package_name | default(_def_xorriso_package_name) }}'
 
+# name of the package that provides rsync
+_rsync_package_name: '{{ rsync_package_name | default(_def_rsync_package_name) }}'
+
 # relative path within the temporary_work_dir_source_files_path to the isolinux.bin file
 _isolinux_bin_path: '{{ isolinux_bin_path | default(_def_isolinux_bin_path) }}'
 


### PR DESCRIPTION
## TL;DR

- The package 'rsync' is used by the module ansible.posix.synchronize
- Task 'extract_files | Extract files of mounted ISO to work directory' fails when package is missing
- Added 'rsync' as a dependency in the same way as 'xorriso'

## The epic explanaition

Hi Steffen,  
I tried your awesome role on a fresh install of RHEL 9.4 and discovered the following task failure do to the missing package `rsync`:

```
TASK [sscheib.rhel_iso_kickstart : extract_files | Extract files of mounted ISO to work directory: /home/jkastnin/downloads/src] ***
task path: /home/jkastnin/proj_rhel_iso_kickstart/roles/sscheib.rhel_iso_kickstart/tasks/extract_files.yml:31
…
    "msg": "Failed to find required executable \"rsync\" in paths: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin"
```

According to `ansible-doc ansible.posix.synchronize` the module is only a wrapper for `rsync` that depends on the package to be present:

> NOTES:
>      * rsync must be installed on both the local and remote host.

To fix this I added `rsync` as a dependency to the role.

In case you have any further questions, you know where to find me.